### PR TITLE
Enhance/stats

### DIFF
--- a/patients/forms.py
+++ b/patients/forms.py
@@ -319,6 +319,15 @@ class DashboardForm(FormLoggerMixin, forms.Form):
     central = ThreeWayToggle()
     midline_extension = ThreeWayToggle()
     
+    # checkbutton for switching to percent
+    show_percent = forms.BooleanField(
+        required=False, initial=False, 
+        widget=forms.widgets.RadioSelect(
+            attrs={"class": "radio is-hidden"},
+            choices=[(True, "percent"), (False, "absolute")]
+        )
+    )
+    
     
     def __init__(self, *args, **kwargs):
         """Extend default initialization to create lots of fields for the 

--- a/patients/static/patients/dashboard.css
+++ b/patients/static/patients/dashboard.css
@@ -48,6 +48,10 @@ div.tag.unk {
     background-color: #C5D5DB;
 }
 
+div.tag.stat-tag {
+    width: 34px;
+}
+
 .barplot {
     width: 100%;
     background-image:

--- a/patients/templates/patients/dashboard.html
+++ b/patients/templates/patients/dashboard.html
@@ -68,15 +68,15 @@
         
                             <div class="columns is-multiline">
                                 <div class="column">
-                                    {% include 'patients/three-way-toggle.html' with name='smoking status' radio_buttons=form.nicotine_abuse stat=stats.nicotine_abuse %}
+                                    {% include 'patients/three-way-toggle.html' with name='smoking status' radio_buttons=form.nicotine_abuse stat=stats.nicotine_abuse show_percent=show_percent %}
                                 </div>
         
                                 <div class="column">
-                                    {% include 'patients/three-way-toggle.html' with name='HPV status' radio_buttons=form.hpv_status stat=stats.hpv_status %}
+                                    {% include 'patients/three-way-toggle.html' with name='HPV status' radio_buttons=form.hpv_status stat=stats.hpv_status show_percent=show_percent %}
                                 </div>
         
                                 <div class="column">
-                                    {% include 'patients/three-way-toggle.html' with name='neck dissection' radio_buttons=form.neck_dissection stat=stats.neck_dissection %}
+                                    {% include 'patients/three-way-toggle.html' with name='neck dissection' radio_buttons=form.neck_dissection stat=stats.neck_dissection show_percent=show_percent %}
                                 </div>
                             </div>
                         </div>
@@ -105,11 +105,11 @@
         
                                     <div class="columns is-multiline">
                                         <div class="column">
-                                            {% include 'patients/three-way-toggle.html' with name='central' radio_buttons=form.central stat=stats.central %}
+                                            {% include 'patients/three-way-toggle.html' with name='central' radio_buttons=form.central stat=stats.central show_percent=show_percent %}
                                         </div>
                 
                                         <div class="column">
-                                            {% include 'patients/three-way-toggle.html' with name='midline extension' radio_buttons=form.midline_extension stat=stats.midline_extension %}
+                                            {% include 'patients/three-way-toggle.html' with name='midline extension' radio_buttons=form.midline_extension stat=stats.midline_extension show_percent=show_percent %}
                                         </div>
                                     </div>
                                 </div>
@@ -126,7 +126,11 @@
                                         </div>
                                         <div class="control">
                                             <p class="button is-info is-static">
+                                                {% if show_percent %}
+                                                <span>{{ stats.subsites|percent:forloop.counter0 }}%</span>
+                                                {% else %}
                                                 <span>{{ stats.subsites|index:forloop.counter0 }}</span>
+                                                {% endif %}
                                             </p>
                                         </div>
                                     </div>
@@ -145,7 +149,11 @@
                                         </div>
                                         <div class="control">
                                             <p class="button is-info is-static">
+                                                {% if show_percent %}
+                                                <span>{{ stats.t_stages|percent:forloop.counter0 }}%</span>
+                                                {% else %}
                                                 <span>{{ stats.t_stages|index:forloop.counter0 }}</span>
+                                                {% endif %}
                                             </p>
                                         </div>
                                     </div>
@@ -209,44 +217,44 @@
                                     <tr>
                                         <td rowspan="3">I</td>
                                         <td>both</td>
-                                        {% include 'patients/lnlrow.html' with lnl="I contralateral" radiobuttons=form.contra_I stat=stats.contra_I %}
+                                        {% include 'patients/lnlrow.html' with lnl="I contralateral" radiobuttons=form.contra_I stat=stats.contra_I show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>a</td>
-                                        {% include 'patients/lnlrow.html' with lnl="Ia contralateral" radiobuttons=form.contra_Ia stat=stats.contra_Ia %}
+                                        {% include 'patients/lnlrow.html' with lnl="Ia contralateral" radiobuttons=form.contra_Ia stat=stats.contra_Ia show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>b</td>
-                                        {% include 'patients/lnlrow.html' with lnl="Ib contralateral" radiobuttons=form.contra_Ib stat=stats.contra_Ib %}
+                                        {% include 'patients/lnlrow.html' with lnl="Ib contralateral" radiobuttons=form.contra_Ib stat=stats.contra_Ib show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td rowspan="3">II</td>
                                         <td>both</td>
-                                        {% include 'patients/lnlrow.html' with lnl="II contralateral" radiobuttons=form.contra_II stat=stats.contra_II %}
+                                        {% include 'patients/lnlrow.html' with lnl="II contralateral" radiobuttons=form.contra_II stat=stats.contra_II show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>a</td>
-                                        {% include 'patients/lnlrow.html' with lnl="IIa contralateral" radiobuttons=form.contra_IIa stat=stats.contra_IIa %}
+                                        {% include 'patients/lnlrow.html' with lnl="IIa contralateral" radiobuttons=form.contra_IIa stat=stats.contra_IIa show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>b</td>
-                                        {% include 'patients/lnlrow.html' with lnl="IIb contralateral" radiobuttons=form.contra_IIb stat=stats.contra_IIb %}
+                                        {% include 'patients/lnlrow.html' with lnl="IIb contralateral" radiobuttons=form.contra_IIb stat=stats.contra_IIb show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">III</td>
-                                        {% include 'patients/lnlrow.html' with lnl="III contralateral" radiobuttons=form.contra_III stat=stats.contra_III %}
+                                        {% include 'patients/lnlrow.html' with lnl="III contralateral" radiobuttons=form.contra_III stat=stats.contra_III show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">IV</td>
-                                        {% include 'patients/lnlrow.html' with lnl="IV contralateral" radiobuttons=form.contra_IV stat=stats.contra_IV %}
+                                        {% include 'patients/lnlrow.html' with lnl="IV contralateral" radiobuttons=form.contra_IV stat=stats.contra_IV show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">V</td>
-                                        {% include 'patients/lnlrow.html' with lnl="V contralateral" radiobuttons=form.contra_V stat=stats.contra_V %}
+                                        {% include 'patients/lnlrow.html' with lnl="V contralateral" radiobuttons=form.contra_V stat=stats.contra_V show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">VII</td>
-                                        {% include 'patients/lnlrow.html' with lnl="VII contralateral" radiobuttons=form.contra_VII stat=stats.contra_VII %}
+                                        {% include 'patients/lnlrow.html' with lnl="VII contralateral" radiobuttons=form.contra_VII stat=stats.contra_VII show_percent=show_percent %}
                                     </tr>
                                 </tbody>
                             </table>
@@ -261,44 +269,44 @@
                                     <tr>
                                         <td rowspan="3">I</td>
                                         <td>both</td>
-                                        {% include 'patients/lnlrow.html' with lnl="I ipsilateral" radiobuttons=form.ipsi_I stat=stats.ipsi_I %}
+                                        {% include 'patients/lnlrow.html' with lnl="I ipsilateral" radiobuttons=form.ipsi_I stat=stats.ipsi_I show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>a</td>
-                                        {% include 'patients/lnlrow.html' with lnl="Ia ipsilateral" radiobuttons=form.ipsi_Ia stat=stats.ipsi_Ia %}
+                                        {% include 'patients/lnlrow.html' with lnl="Ia ipsilateral" radiobuttons=form.ipsi_Ia stat=stats.ipsi_Ia show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>b</td>
-                                        {% include 'patients/lnlrow.html' with lnl="Ib ipsilateral" radiobuttons=form.ipsi_Ib stat=stats.ipsi_Ib %}
+                                        {% include 'patients/lnlrow.html' with lnl="Ib ipsilateral" radiobuttons=form.ipsi_Ib stat=stats.ipsi_Ib show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td rowspan="3">II</td>
                                         <td>both</td>
-                                        {% include 'patients/lnlrow.html' with lnl="II ipsilateral" radiobuttons=form.ipsi_II stat=stats.ipsi_II %}
+                                        {% include 'patients/lnlrow.html' with lnl="II ipsilateral" radiobuttons=form.ipsi_II stat=stats.ipsi_II show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>a</td>
-                                        {% include 'patients/lnlrow.html' with lnl="IIa ipsilateral" radiobuttons=form.ipsi_IIa stat=stats.ipsi_IIa %}
+                                        {% include 'patients/lnlrow.html' with lnl="IIa ipsilateral" radiobuttons=form.ipsi_IIa stat=stats.ipsi_IIa show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td>b</td>
-                                        {% include 'patients/lnlrow.html' with lnl="IIb ipsilateral" radiobuttons=form.ipsi_IIb stat=stats.ipsi_IIb %}
+                                        {% include 'patients/lnlrow.html' with lnl="IIb ipsilateral" radiobuttons=form.ipsi_IIb stat=stats.ipsi_IIb show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">III</td>
-                                        {% include 'patients/lnlrow.html' with lnl="III ipsilateral" radiobuttons=form.ipsi_III stat=stats.ipsi_III %}
+                                        {% include 'patients/lnlrow.html' with lnl="III ipsilateral" radiobuttons=form.ipsi_III stat=stats.ipsi_III show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">IV</td>
-                                        {% include 'patients/lnlrow.html' with lnl="IV ipsilateral" radiobuttons=form.ipsi_IV stat=stats.ipsi_IV %}
+                                        {% include 'patients/lnlrow.html' with lnl="IV ipsilateral" radiobuttons=form.ipsi_IV stat=stats.ipsi_IV show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">V</td>
-                                        {% include 'patients/lnlrow.html' with lnl="V ipsilateral" radiobuttons=form.ipsi_V stat=stats.ipsi_V %}
+                                        {% include 'patients/lnlrow.html' with lnl="V ipsilateral" radiobuttons=form.ipsi_V stat=stats.ipsi_V show_percent=show_percent %}
                                     </tr>
                                     <tr>
                                         <td colspan="2">VII</td>
-                                        {% include 'patients/lnlrow.html' with lnl="VII ipsilateral" radiobuttons=form.ipsi_VII stat=stats.ipsi_VII %}
+                                        {% include 'patients/lnlrow.html' with lnl="VII ipsilateral" radiobuttons=form.ipsi_VII stat=stats.ipsi_VII show_percent=show_percent %}
                                     </tr>
                                 </tbody>
                             </table>
@@ -309,11 +317,32 @@
                 <div class="box">
                     <div class="level">
                         <div class="level-left">
-                            
+                            <div class="level-item">
+                                <div class="field has-addons">
+                                    {% for radio in form.show_percent %}
+                                    <div class="control">
+                                        {{ radio.tag }}
+                                        <label for="{{ radio.id_for_label }}" class="tag button is-medium is-info">
+                                            {% if radio.choice_label == 'percent' %}
+                                            <span class="icon">
+                                                <i class="fas fa-percentage"></i>   
+                                            </span>
+                                            <span>percent</span>
+                                            {% elif radio.choice_label == 'absolute' %}
+                                            <span>absolute</span>
+                                            <span class="icon">
+                                                <i class="fab fa-slack-hash"></i>
+                                            </span>
+                                            {% endif %}
+                                        </label>
+                                    </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
                         </div>
                         <div class="level-right">
                             <div class="level-item">
-                                <p class="button is-medium is-primary is-light is-rounded is-outlined" style="width: 0;" id="show-help" data-tooltip="Display documentation on how to use this dashboard">
+                                <p class="button is-medium is-primary is-light is-rounded is-outlined" style="width: 0;" id="show-help-modal" data-tooltip="Display documentation on how to use this dashboard">
                                     <span class="icon">
                                         <i class="fas fa-question"></i>
                                     </span>

--- a/patients/templates/patients/dashboard.html
+++ b/patients/templates/patients/dashboard.html
@@ -68,45 +68,15 @@
         
                             <div class="columns is-multiline">
                                 <div class="column">
-                                    <p class="heading has-text-centered">smoking status</p>
-                                    <div class="field has-addons is-justify-content-center">
-                                        {% for radio in form.nicotine_abuse %}
-                                        <div class="control">
-                                            {{ radio.tag }}
-                                            <label for="{{ radio.id_for_label }}" class="tag button is-info {{ radio.choice_label }}">
-                                                <i class="fas fa-lg fa-{{ radio.choice_label }}"></i>
-                                            </label>
-                                        </div>
-                                        {% endfor %}
-                                    </div>
+                                    {% include 'patients/three-way-toggle.html' with name='smoking status' radio_buttons=form.nicotine_abuse stat=stats.nicotine_abuse %}
                                 </div>
         
                                 <div class="column">
-                                    <p class="heading has-text-centered">HPV status</p>
-                                    <div class="field has-addons is-justify-content-center">
-                                        {% for radio in form.hpv_status %}
-                                        <div class="control">
-                                            {{ radio.tag }}
-                                            <label for="{{ radio.id_for_label }}" class="tag button is-info {{ radio.choice_label }}">
-                                                <i class="fas fa-lg fa-{{ radio.choice_label }}"></i>
-                                            </label>
-                                        </div>
-                                        {% endfor %}
-                                    </div>
+                                    {% include 'patients/three-way-toggle.html' with name='HPV status' radio_buttons=form.hpv_status stat=stats.hpv_status %}
                                 </div>
         
                                 <div class="column">
-                                    <p class="heading has-text-centered">neck dissection</p>
-                                    <div class="field has-addons is-justify-content-center">
-                                        {% for radio in form.neck_dissection %}
-                                        <div class="control">
-                                            {{ radio.tag }}
-                                            <label for="{{ radio.id_for_label }}" class="tag button is-info {{ radio.choice_label }}">
-                                                <i class="fas fa-lg fa-{{ radio.choice_label }}"></i>
-                                            </label>
-                                        </div>
-                                        {% endfor %}
-                                    </div>
+                                    {% include 'patients/three-way-toggle.html' with name='neck dissection' radio_buttons=form.neck_dissection stat=stats.neck_dissection %}
                                 </div>
                             </div>
                         </div>
@@ -135,31 +105,11 @@
         
                                     <div class="columns is-multiline">
                                         <div class="column">
-                                            <p class="heading has-text-centered">central</p>
-                                            <div class="field has-addons is-justify-content-center">
-                                                {% for radio in form.central %}
-                                                <p class="control">
-                                                    {{ radio.tag }}
-                                                    <label for="{{ radio.id_for_label }}" class="tag button is-info {{ radio.choice_label }}">
-                                                        <i class="fas fa-lg fa-{{ radio.choice_label }}"></i>
-                                                    </label>
-                                                </p>
-                                                {% endfor %}
-                                            </div>
+                                            {% include 'patients/three-way-toggle.html' with name='central' radio_buttons=form.central stat=stats.central %}
                                         </div>
                 
                                         <div class="column">
-                                            <p class="heading has-text-centered">midline extension</p>
-                                            <div class="field has-addons is-justify-content-center">
-                                                {% for radio in form.midline_extension %}
-                                                <p class="control">
-                                                    {{ radio.tag }}
-                                                    <label for="{{ radio.id_for_label }}" class="tag button is-info {{ radio.choice_label }}">
-                                                        <i class="fas fa-lg fa-{{ radio.choice_label }}"></i>
-                                                    </label>
-                                                </p>
-                                                {% endfor %}
-                                            </div>
+                                            {% include 'patients/three-way-toggle.html' with name='midline extension' radio_buttons=form.midline_extension stat=stats.midline_extension %}
                                         </div>
                                     </div>
                                 </div>

--- a/patients/templates/patients/lnlrow.html
+++ b/patients/templates/patients/lnlrow.html
@@ -18,20 +18,32 @@
         <div class="control">
             <span class="tag barplot-legend is-danger is-light" 
                   data-tooltip="{{ stat|index:1 }} of {{ stat|sum }} ({{ stat|percent:1 }}%) patients have metastases in LNL {{ lnl }}">
+                {% if show_percent %}
+                {{ stat|percent:1 }}%
+                {% else %}
                 {{ stat|index:1 }}
+                {% endif %}
             </span>
         </div>
         <div class="control is-expanded">
             <span class="tag barplot has-text-white" 
                   data-tooltip="{{ stat|index:0 }} of {{ stat|sum }} ({{ stat|percent:0 }}%) patients have unknown involvement in LNL {{ lnl }}"
                   style="background-size: {{ stat|bar:'1,100' }}% 100%, calc({{ stat|bar:'1,100' }}% + {{ stat|bar:'0,100' }}%) 100%, 100% 100%;">
-                  {{ stat|index:0 }}
+                {% if show_percent %}
+                {{ stat|percent:0 }}%
+                {% else %}
+                {{ stat|index:0 }}
+                {% endif %}
             </span>
         </div>
         <div class="control">
             <span class="tag barplot-legend is-success is-light" 
                   data-tooltip="{{ stat|index:-1 }} of {{ stat|sum }} ({{ stat|percent:-1 }}%) patients do not have metastases in LNL {{ lnl }}">
+                {% if show_percent %}
+                {{ stat|percent:-1 }}%
+                {% else %}
                 {{ stat|index:-1 }}
+                {% endif %}
             </span>
         </div>
     </div>

--- a/patients/templates/patients/three-way-toggle.html
+++ b/patients/templates/patients/three-way-toggle.html
@@ -16,7 +16,11 @@
 <div class="tags has-addons is-justify-content-center">
     {% for i in '102' %}
     <div class="tag stat-tag button is-static">
+        {% if show_percent %}
+        {{ stat|percent:i }}%
+        {% else %}
         {{ stat|index:i }}
+        {% endif %}
     </div>
     {% endfor %}
 </div>

--- a/patients/templates/patients/three-way-toggle.html
+++ b/patients/templates/patients/three-way-toggle.html
@@ -1,0 +1,22 @@
+{% load mytags %}
+
+<p class="heading has-text-centered">{{ name }}</p>
+<div class="field has-addons is-justify-content-center" 
+     style="margin-bottom: 6px;">
+    {% for radio in radio_buttons %}
+    <div class="control">
+        {{ radio.tag }}
+        <label for="{{ radio.id_for_label }}" class="tag button is-info {{ radio.choice_label }}">
+            <i class="fas fa-lg fa-{{ radio.choice_label }}"></i>
+        </label>
+    </div>
+    {% endfor %}
+</div>
+
+<div class="tags has-addons is-justify-content-center">
+    {% for i in '102' %}
+    <div class="tag stat-tag button is-static">
+        {{ stat|index:i }}
+    </div>
+    {% endfor %}
+</div>

--- a/patients/templatetags/mytags.py
+++ b/patients/templatetags/mytags.py
@@ -11,7 +11,7 @@ register = template.Library()
 
 @register.filter(name="index")
 def index(indexable, i):
-    return indexable[i]
+    return indexable[int(f"{i}".lower())]
 
 @register.filter(name="bar")
 def bar(indexable, argstr):

--- a/patients/templatetags/mytags.py
+++ b/patients/templatetags/mytags.py
@@ -27,7 +27,8 @@ def mysum(indexable):
 
 @register.filter(name="percent")
 def percent(indexable, i):
-    return f"{100 * indexable[i] / sum(indexable):.1f}"
+    i = int(f"{i}".lower())
+    return f"{100 * indexable[i] / sum(indexable):.0f}"
 
 
 


### PR DESCRIPTION
Improves how the statistics are displayed in the dashboard. Namely, it now displays how many patients in the selection are smokers, HPV positive, have undergone neck dissection, have central tumors or tumors with midline extension. Also, it is now possible to switch between percent and absolute numbers for all displayed values.